### PR TITLE
Move console.log call

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ async function main() {
     });
 
     await Promise.all(reqs);
+    
+    console.log(JSON.stringify(issueTitles));
 }
 
 main();
-
-console.log(JSON.stringify(issueTitles));


### PR DESCRIPTION
You're `console.log(JSON.stringify(issueTitles));` call is showing an empty array because `main()` hasn't completed by the time it's executed. Moving `console.log` to execute right after `await Promise.all` fixes this.
